### PR TITLE
Change github url to use http

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ play and build with Hoodie.
 ## Setup
 
 ```
-git clone git@github.com:hoodiehq/hoodie-app-something-tracker.git
+git clone https://github.com/hoodiehq/hoodie-app-something-tracker.git
 cd hoodie-app-something-tracker
 npm install --no-optional --production
 cp .hoodierc-example .hoodierc


### PR DESCRIPTION
When cloning the repo I got this error:

    $ git clone git@github.com:hoodiehq/hoodie-app-something-tracker.git
    Klone nach 'hoodie-app-something-tracker' ...
    Permission denied (publickey).
    fatal: Could not read from remote repository.
    
    Please make sure you have the correct access rights
    and the repository exists.

Changing the github url to `https://github.com/hoodiehq/hoodie-app-something-tracker.git` fixed this.